### PR TITLE
if image is GIF - ignore resize

### DIFF
--- a/dialogs/base64image.js
+++ b/dialogs/base64image.js
@@ -414,6 +414,9 @@ CKEDITOR.dialog.add("base64imageDialog", function(editor){
 			/* Insert new image */
 			if(!selectedImg) editor.insertElement(newImg);
 			
+            		/* Ignore GIF resize */
+            		if (newImg.$.src.match(/data:image\/gif;base64/)) return;
+			
 			/* Resize image */
 			if(editor.plugins.imageresize) editor.plugins.imageresize.resize(editor, newImg, 800, 800);
 			


### PR DESCRIPTION
If the image is Animated GIF the resize plugin convert the GIF image into base64 PNG image and the GIF is no longer animated.