### PR TITLE
Made plugin available when 'item by item' toolbar configuration is used

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -10,7 +10,7 @@ CKEDITOR.plugins.add("base64image", {
 	hidpi	:	true,
     init	: 	function(editor){
 					var pluginName = 'base64imageDialog';
-					
+					editor.ui.addToolbarGroup('base64image', 'insert');
 					editor.ui.addButton("base64image", {
 						label: editor.lang.common.image,
 						command: pluginName,


### PR DESCRIPTION
https://ckeditor.com/docs/ckeditor4/latest/features/toolbarconcepts.html#item-by-item-configuration
You can now add base64image to your config like this:

`{
	name: 'insert',
	items: ['base64image', 'Table', ...]
}`